### PR TITLE
ENG-2403: Use unrestricted permissions when creating shared memory segments

### DIFF
--- a/src/cpp/utils/shared_memory/RobustExclusiveLock.hpp
+++ b/src/cpp/utils/shared_memory/RobustExclusiveLock.hpp
@@ -180,7 +180,11 @@ private:
         else
         {
             *was_lock_created = true;
+
+            mode_t old_mask;
+            old_mask = umask(000);
             fd = open(file_path.c_str(), O_CREAT | O_RDONLY, 0666);
+            umask(old_mask);
         }
 
         if (fd == -1)

--- a/src/cpp/utils/shared_memory/SharedMemSegment.hpp
+++ b/src/cpp/utils/shared_memory/SharedMemSegment.hpp
@@ -327,9 +327,11 @@ public:
             size_t size)
         : SharedSegmentBase(name)
     {
+        boost::interprocess::permissions unrestricted_permissions;
+        unrestricted_permissions.set_unrestricted();
         segment_ = std::unique_ptr<managed_shared_memory_type>(
             new managed_shared_memory_type(boost::interprocess::create_only, name.c_str(),
-            static_cast<Offset>(size + EXTRA_SEGMENT_SIZE)));
+            static_cast<Offset>(size + EXTRA_SEGMENT_SIZE), 0, unrestricted_permissions));
     }
 
     SharedSegment(
@@ -356,8 +358,10 @@ public:
             size_t size)
         : SharedSegmentBase(name)
     {
+        boost::interprocess::permissions unrestricted_permissions;
+        unrestricted_permissions.set_unrestricted();
         segment_ = std::unique_ptr<managed_shared_memory_type>(
-            new managed_shared_memory_type(boost::interprocess::create_only, name.c_str(), static_cast<Offset>(size)));
+            new managed_shared_memory_type(boost::interprocess::create_only, name.c_str(), static_cast<Offset>(size), 0, unrestricted_permissions));
     }
 
     ~SharedSegment()


### PR DESCRIPTION
Use unrestricted permissions when creating mutexes, locks and shared memory segments to allow applications started by different users to communicate.